### PR TITLE
fix: typo dev environment extra paths not working

### DIFF
--- a/plugin/constants.py
+++ b/plugin/constants.py
@@ -4,5 +4,5 @@ assert __package__
 
 PACKAGE_NAME = __package__.partition(".")[0]
 
-SERVER_SETTING_ANALYSIS_EXTRAPATHS = 'basedpyright.analysis.extraPaths"'
+SERVER_SETTING_ANALYSIS_EXTRAPATHS = "basedpyright.analysis.extraPaths"
 SERVER_SETTING_DEV_ENVIRONMENT = "basedpyright.dev_environment"


### PR DESCRIPTION
fix typo in setting name