### PR TITLE
fix: don't include server version by default in the status

### DIFF
--- a/LSP-basedpyright.sublime-settings
+++ b/LSP-basedpyright.sublime-settings
@@ -15,7 +15,9 @@
 	"settings": {
 		// The (Jinja2) template of the status bar text which is inside the parentheses `(...)`.
 		// See https://jinja.palletsprojects.com/templates/
-		"statusText": "{% set parts = [] %}{% if server_version %}{% do parts.append('v' + server_version) %}{% endif %}{% if venv %}{% do parts.append('venv: ' + venv.venv_prompt) %}{% do parts.append('py: ' + venv.python_version) %}{% do parts.append('by: ' + venv.finder_name) %}{% endif %}{{ parts|join('; ') }}",
+		// Examples:
+		// - server version: {% if server_version %}{% do parts.append('v' + server_version) %}{% endif %}
+		"statusText": "{% set parts = [] %}{% if venv %}{% do parts.append('venv: ' + venv.venv_prompt) %}{% do parts.append('py: ' + venv.python_version) %}{% do parts.append('by: ' + venv.finder_name) %}{% endif %}{{ parts|join('; ') }}",
 		// The strategies used to find a virtual environment in order.
 		"venvStrategies": [
 			"st_project_data",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -505,7 +505,7 @@
                       "$ref": "sublime://basedpyright#/definitions/venvPath"
                     },
                     "statusText": {
-                      "default": "{% set parts = [] %}{% if server_version %}{% do parts.append('v' + server_version) %}{% endif %}{% if venv %}{% do parts.append('venv: ' + venv.venv_prompt) %}{% do parts.append('py: ' + venv.python_version) %}{% do parts.append('by: ' + venv.finder_name) %}{% endif %}{{ parts|join('; ') }}",
+                      "default": "{% set parts = [] %}{% if venv %}{% do parts.append('venv: ' + venv.venv_prompt) %}{% do parts.append('py: ' + venv.python_version) %}{% do parts.append('by: ' + venv.finder_name) %}{% endif %}{{ parts|join('; ') }}",
                       "markdownDescription": "The (Jinja2) template of the status bar text which is inside the parentheses `(...)`. See https://jinja.palletsprojects.com/templates/",
                       "type": "string"
                     },


### PR DESCRIPTION
Feel free to chime in with opinions but I don't think that showing a server version by default is benefiting most of the users.

- no other servers do that
- showing version that is specific to the project (like venv or typescript in case of `typescript-language-server`) is a different thing and that can be useful but constantly changing server version I don't think so.
- it takes valuable real estate in the status and makes it look more busy