### PR TITLE
feat: expose unittesting module in dev_environment

### DIFF
--- a/plugin/dev_environment/impl/sublime_text.py
+++ b/plugin/dev_environment/impl/sublime_text.py
@@ -54,6 +54,9 @@ class BaseVersionedSublimeTextDevEnvironmentHandler(BaseDevEnvironmentHandler, A
         re_pattern = re.compile(r"(python)(3\.?[0-9]+)", flags=re.IGNORECASE)
         dep_dirs = [re_pattern.sub(Rf"\g<1>{self.python_version_no_dot}", dep_dir) for dep_dir in dep_dirs]
 
+        # Expose unittesting module.
+        dep_dirs.append(os.path.join(sublime.packages_path(), 'UnitTesting'))
+
         # move the "Packages/" to the last
         # @see https://github.com/sublimelsp/LSP-pyright/pull/26#discussion_r520747708
         packages_path = sublime.packages_path()

--- a/plugin/dev_environment/impl/sublime_text.py
+++ b/plugin/dev_environment/impl/sublime_text.py
@@ -55,7 +55,7 @@ class BaseVersionedSublimeTextDevEnvironmentHandler(BaseDevEnvironmentHandler, A
         dep_dirs = [re_pattern.sub(Rf"\g<1>{self.python_version_no_dot}", dep_dir) for dep_dir in dep_dirs]
 
         # Expose unittesting module.
-        dep_dirs.append(os.path.join(sublime.packages_path(), 'UnitTesting'))
+        dep_dirs.append(os.path.join(sublime.packages_path(), "UnitTesting"))
 
         # move the "Packages/" to the last
         # @see https://github.com/sublimelsp/LSP-pyright/pull/26#discussion_r520747708

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ignore_missing_imports = true
 pythonVersion = '3.8'
 reportAny = "none"
 reportUnusedCallResult = "none"
+typeCheckingMode = "standard"
 
 [tool.ruff]
 preview = true


### PR DESCRIPTION
Think it makes sense that unittesting module's types are by default exposed in dev environment.